### PR TITLE
Add scope (OPTIONAL) into Token\Response::allowedProperties

### DIFF
--- a/src/InoOicClient/Oic/Token/Param.php
+++ b/src/InoOicClient/Oic/Token/Param.php
@@ -31,4 +31,6 @@ class Param
     const REFRESH_TOKEN = 'refresh_token';
 
     const ID_TOKEN = 'id_token';
+
+    const SCOPE = 'scope';
 }

--- a/src/InoOicClient/Oic/Token/Response.php
+++ b/src/InoOicClient/Oic/Token/Response.php
@@ -28,6 +28,7 @@ class Response extends AbstractEntity
         Param::TOKEN_TYPE,
         Param::REFRESH_TOKEN,
         Param::EXPIRES_IN,
-        Param::ID_TOKEN
+        Param::ID_TOKEN,
+        Param::SCOPE,
     );
 }


### PR DESCRIPTION
Access Token Response might contain 'scope'.
So, we have to add 'scope' into $allowedProperties.

4.4.3.  Access Token Response
https://tools.ietf.org/html/rfc6749#section-4.4.3

5.1.  Successful Response
https://tools.ietf.org/html/rfc6749#section-5.1
