### PR TITLE
Properly pass options to HttpClient

### DIFF
--- a/src/InoOicClient/Oic/AbstractHttpRequestDispatcher.php
+++ b/src/InoOicClient/Oic/AbstractHttpRequestDispatcher.php
@@ -139,6 +139,7 @@ abstract class AbstractHttpRequestDispatcher
     public function sendHttpRequest(Http\Request $httpRequest)
     {
         $this->setLastHttpRequest($httpRequest);
+        $this->httpClient->setOptions($this->options->get(self::OPT_HTTP_OPTIONS, array()));
         
         try {
             $httpResponse = $this->httpClient->send($httpRequest);

--- a/src/InoOicClient/Oic/Token/Dispatcher.php
+++ b/src/InoOicClient/Oic/Token/Dispatcher.php
@@ -30,7 +30,7 @@ class Dispatcher extends AbstractHttpRequestDispatcher
     public function getHttpRequestBuilder()
     {
         if (! $this->httpRequestBuilder instanceof HttpRequestBuilder) {
-            $this->httpRequestBuilder = new HttpRequestBuilder($this->options->get(self::OPT_HTTP_OPTIONS, array()));
+            $this->httpRequestBuilder = new HttpRequestBuilder();
         }
         return $this->httpRequestBuilder;
     }


### PR DESCRIPTION
The Token dispatcher does not properly pass the `http_options` array to the HttpClient; instead, they were passed to the Request builder, but then nothing happened with them. Regardless, they must be applied to the client.

This may fix a problem where the request was failing with:
```
Unable to enable crypto on TCP connection example.com: make sure the "sslcafile" or "sslcapath" option are properly set for the environment.
```

In this event, you will want to set the options with something like:
```
$tokenDispatcher->setOptions(['http_options' => ['sslcapath' => $source->sslcapath]]);
```