### PR TITLE
Run tests on different php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ matrix:
         - php: '7.4'
 
 script:
-  - ./vendor/bin/phpunit -c tests/ --coverage-text
+  - ./vendor/bin/phpunit -c tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: php
+dist: trusty
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
+  - composer install
+
+matrix:
+    include:
+        - php: '5.3'
+          dist: precise
+        - php: '5.4'
+          dist: precise
+        - php: '5.5'
+          dist: precise
+        - php: '5.6'
+        - php: '7.0'
+        - php: '7.1'
+        - php: '7.2'
+        - php: '7.3'
+        - php: '7.4'
+
+script:
+  - ./vendor/bin/phpunit -c tests/ --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": "~4.4"
+        "phpunit/phpunit": "~4.4 || ~5.0"
     },
 
     "autoload" : {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,7 @@
 <?php
 require __DIR__ . '/../init_autoload.php';
 
+// Do not fail on deprecation warnings
+PHPUnit_Framework_Error_Deprecated::$enabled = false;
+
 define('TESTS_ROOT', __DIR__);

--- a/tests/unit/InoOicClientTest/Client/Authenticator/AbstractSecretAuthenticatorTest.php
+++ b/tests/unit/InoOicClientTest/Client/Authenticator/AbstractSecretAuthenticatorTest.php
@@ -9,7 +9,8 @@ class AbstractSecretAuthenticatorTest extends \PHPUnit_Framework_Testcase
 
     public function testConfigureHttpRequest()
     {
-        $httpRequest = $this->getMock('Laminas\Http\Request');
+        $httpRequest = $this->getMockBuilder('Laminas\Http\Request')
+            ->getMock();
         $clientId = '123';
         $clientSecret = 'abc';
         

--- a/tests/unit/InoOicClientTest/Client/Authenticator/AuthenticatorFactoryTest.php
+++ b/tests/unit/InoOicClientTest/Client/Authenticator/AuthenticatorFactoryTest.php
@@ -14,7 +14,7 @@ class AuthenticatorFactoryTest extends \PHPUnit_Framework_Testcase
     {
         $this->setExpectedException('InoOicClient\Client\Authenticator\Exception\MissingAuthenticationInfoException');
         
-        $client = $this->getMock('InoOicClient\Client\ClientInfo');
+        $client = $this->getMockBuilder('InoOicClient\Client\ClientInfo')->getMock();
         $factory = new AuthenticatorFactory();
         
         $authenticator = $factory->createAuthenticator($client);

--- a/tests/unit/InoOicClientTest/Client/Authenticator/SecretBasicTest.php
+++ b/tests/unit/InoOicClientTest/Client/Authenticator/SecretBasicTest.php
@@ -28,12 +28,14 @@ class SecretBasicTest extends \PHPUnit_Framework_Testcase
             ->with($clientId, $secret)
             ->will($this->returnValue($authString));
         
-        $headers = $this->getMock('Laminas\Http\Headers');
+        $headers = $this->getMockBuilder('Laminas\Http\Headers')
+            ->getMock();
         $headers->expects($this->once())
             ->method('addHeaderLine')
             ->with('Authorization', $authHeaderValue);
         
-        $httpRequest = $this->getMock('Laminas\Http\Request');
+        $httpRequest = $this->getMockBuilder('Laminas\Http\Request')
+            ->getMock();
         $httpRequest->expects($this->once())
             ->method('getHeaders')
             ->will($this->returnValue($headers));

--- a/tests/unit/InoOicClientTest/Client/Authenticator/SecretPostTest.php
+++ b/tests/unit/InoOicClientTest/Client/Authenticator/SecretPostTest.php
@@ -21,7 +21,8 @@ class SecretPostTest extends \PHPUnit_Framework_Testcase
          * of either Iterator or IteratorAggregate in Unknown on line 0
          */
         //$postParams = $this->getMock('Laminas\Stdlib\ParametersInterface');
-        $postParams = $this->getMock('Laminas\Stdlib\Parameters');
+        $postParams = $this->getMockBuilder('Laminas\Stdlib\Parameters')
+            ->getMock();
         
         $postParams->expects($this->at(0))
             ->method('set')
@@ -30,7 +31,7 @@ class SecretPostTest extends \PHPUnit_Framework_Testcase
             ->method('set')
             ->with(Param::CLIENT_SECRET, $clientSecret);
         
-        $httpRequest = $this->getMock('Laminas\Http\Request');
+        $httpRequest = $this->getMockBuilder('Laminas\Http\Request')->getMock();
         $httpRequest->expects($this->once())
             ->method('getPost')
             ->will($this->returnValue($postParams));

--- a/tests/unit/InoOicClientTest/Client/ClientInfoTest.php
+++ b/tests/unit/InoOicClientTest/Client/ClientInfoTest.php
@@ -13,7 +13,7 @@ class ClientInfoTest extends \PHPUnit_Framework_TestCase
     {
         $clientId = '123';
         $redirectUri = 'https://client/redirect';
-        $authenticationInfo = $this->getMock('InoOicClient\Client\AuthenticationInfo');
+        $authenticationInfo = $this->getMockBuilder('InoOicClient\Client\AuthenticationInfo')->getMock();
         $name = 'test client';
         $description = 'test client desc';
         $authEndpoint = 'https://server/auth';

--- a/tests/unit/InoOicClientTest/Entity/AbstractEntityTest.php
+++ b/tests/unit/InoOicClientTest/Entity/AbstractEntityTest.php
@@ -152,7 +152,7 @@ class AbstractEntityTest extends \PHPUnit_Framework_TestCase
 
     protected function createMapperMock()
     {
-        $mapper = $this->getMock('InoOicClient\Entity\PropertyMapperInterface');
+        $mapper = $this->getMockBuilder('InoOicClient\Entity\PropertyMapperInterface')->getMock();
         
         return $mapper;
     }

--- a/tests/unit/InoOicClientTest/Flow/AbstractFlowTest.php
+++ b/tests/unit/InoOicClientTest/Flow/AbstractFlowTest.php
@@ -62,7 +62,7 @@ class AbstractFlowTest extends \PHPUnit_Framework_Testcase
     public function testSetAuthorizationDispatcher()
     {
         $flow = $this->createFlow();
-        $dispatcher = $this->getMock('InoOicClient\Oic\Authorization\Dispatcher');
+        $dispatcher = $this->getMockBuilder('InoOicClient\Oic\Authorization\Dispatcher')->getMock();
         $flow->setAuthorizationDispatcher($dispatcher);
         $this->assertSame($dispatcher, $flow->getAuthorizationDispatcher());
     }
@@ -90,7 +90,7 @@ class AbstractFlowTest extends \PHPUnit_Framework_Testcase
     public function testSetTokenDispatcher()
     {
         $flow = $this->createFlow();
-        $dispatcher = $this->getMock('InoOicClient\Oic\Token\Dispatcher');
+        $dispatcher = $this->getMockBuilder('InoOicClient\Oic\Token\Dispatcher')->getMock();
         $flow->setTokenDispatcher($dispatcher);
         $this->assertSame($dispatcher, $flow->getTokenDispatcher());
     }
@@ -110,7 +110,7 @@ class AbstractFlowTest extends \PHPUnit_Framework_Testcase
     public function testSetUserInfoDispatcher()
     {
         $flow = $this->createFlow();
-        $dispatcher = $this->getMock('InoOicClient\Oic\UserInfo\Dispatcher');
+        $dispatcher = $this->getMockBuilder('InoOicClient\Oic\UserInfo\Dispatcher')->getMock();
         $flow->setUserInfoDispatcher($dispatcher);
         $this->assertSame($dispatcher, $flow->getUserInfoDispatcher());
     }
@@ -134,7 +134,7 @@ class AbstractFlowTest extends \PHPUnit_Framework_Testcase
     public function testSetClientInfo()
     {
         $flow = $this->createFlow();
-        $clientInfo = $this->getMock('InoOicClient\Client\ClientInfo');
+        $clientInfo = $this->getMockBuilder('InoOicClient\Client\ClientInfo')->getMock();
         $flow->setClientInfo($clientInfo);
         $this->assertSame($clientInfo, $flow->getClientInfo());
     }
@@ -151,7 +151,7 @@ class AbstractFlowTest extends \PHPUnit_Framework_Testcase
     public function testSetHttpClientFactory()
     {
         $flow = $this->createFlow();
-        $factory = $this->getMock('InoOicClient\Http\ClientFactory');
+        $factory = $this->getMockBuilder('InoOicClient\Http\ClientFactory')->getMock();
         $flow->setHttpClientFactory($factory);
         $this->assertSame($factory, $flow->getHttpClientFactory());
     }
@@ -166,7 +166,7 @@ class AbstractFlowTest extends \PHPUnit_Framework_Testcase
             Basic::OPT_HTTP_CLIENT => $httpOptions
         );
         $httpClient = $this->createHttpClientMock();
-        $factory = $this->getMock('InoOicClient\Http\ClientFactory');
+        $factory = $this->getMockBuilder('InoOicClient\Http\ClientFactory')->getMock();
         $factory->expects($this->once())
             ->method('createHttpClient')
             ->with($httpOptions)
@@ -203,14 +203,14 @@ class AbstractFlowTest extends \PHPUnit_Framework_Testcase
 
     protected function createStateManagerMock()
     {
-        $stateManager = $this->getMock('InoOicClient\Oic\Authorization\State\Manager');
+        $stateManager = $this->getMockBuilder('InoOicClient\Oic\Authorization\State\Manager')->getMock();
         return $stateManager;
     }
 
 
     protected function createHttpClientMock()
     {
-        $httpClient = $this->getMock('Laminas\Http\Client');
+        $httpClient = $this->getMockBuilder('Laminas\Http\Client')->getMock();
         return $httpClient;
     }
 }

--- a/tests/unit/InoOicClientTest/Flow/BasicTest.php
+++ b/tests/unit/InoOicClientTest/Flow/BasicTest.php
@@ -36,7 +36,7 @@ class BasicTest extends \PHPUnit_Framework_Testcase
             ->with($scope, $responseType)
             ->will($this->returnValue($request));
         
-        $dispatcher = $this->getMock('InoOicClient\Oic\Authorization\Dispatcher');
+        $dispatcher = $this->getMockBuilder('InoOicClient\Oic\Authorization\Dispatcher')->getMock();
         $dispatcher->expects($this->once())
             ->method('createAuthorizationRequestUri')
             ->with($request)
@@ -59,7 +59,7 @@ class BasicTest extends \PHPUnit_Framework_Testcase
             ->method('getCode')
             ->will($this->returnValue($code));
         
-        $dispatcher = $this->getMock('InoOicClient\Oic\Authorization\Dispatcher');
+        $dispatcher = $this->getMockBuilder('InoOicClient\Oic\Authorization\Dispatcher')->getMock();
         $dispatcher->expects($this->once())
             ->method('getAuthorizationResponse')
             ->will($this->returnValue($response));
@@ -96,7 +96,8 @@ class BasicTest extends \PHPUnit_Framework_Testcase
             ->method('getAccessToken')
             ->will($this->returnValue($token));
         
-        $dispatcher = $this->getMock('InoOicClient\Oic\Token\Dispatcher');
+        $dispatcher = $this->getMockBuilder('InoOicClient\Oic\Token\Dispatcher')
+            ->getMock();
         $dispatcher->expects($this->once())
             ->method('sendTokenRequest')
             ->with($request)
@@ -137,7 +138,8 @@ class BasicTest extends \PHPUnit_Framework_Testcase
             ->method('getClaims')
             ->will($this->returnValue($claims));
         
-        $dispatcher = $this->getMock('InoOicClient\Oic\UserInfo\Dispatcher');
+        $dispatcher = $this->getMockBuilder('InoOicClient\Oic\UserInfo\Dispatcher')
+            ->getMock();
         $dispatcher->expects($this->once())
             ->method('sendUserInfoRequest')
             ->with($request)
@@ -265,7 +267,8 @@ class BasicTest extends \PHPUnit_Framework_Testcase
         $responseType = array(
             'code'
         );
-        $clientInfo = $this->getMock('InoOicClient\Client\ClientInfo');
+        $clientInfo = $this->getMockBuilder('InoOicClient\Client\ClientInfo')
+            ->getMock();
         $this->flow->setClientInfo($clientInfo);
         
         $request = $this->flow->createAuthorizationRequest($scope, $responseType);
@@ -279,7 +282,8 @@ class BasicTest extends \PHPUnit_Framework_Testcase
     public function testCreateTokenRequest()
     {
         $code = '123';
-        $clientInfo = $this->getMock('InoOicClient\Client\ClientInfo');
+        $clientInfo = $this->getMockBuilder('InoOicClient\Client\ClientInfo')
+            ->getMock();
         $this->flow->setClientInfo($clientInfo);
         
         $request = $this->flow->createTokenRequest($code);
@@ -292,7 +296,8 @@ class BasicTest extends \PHPUnit_Framework_Testcase
     public function testCreateUserInfoRequest()
     {
         $token = 'abc';
-        $clientInfo = $this->getMock('InoOicClient\Client\ClientInfo');
+        $clientInfo = $this->getMockBuilder('InoOicClient\Client\ClientInfo')
+            ->getMock();
         $this->flow->setClientInfo($clientInfo);
         
         $request = $this->flow->createUserInfoRequest($token);

--- a/tests/unit/InoOicClientTest/Oic/AbstractHttpRequestDispatcherTest.php
+++ b/tests/unit/InoOicClientTest/Oic/AbstractHttpRequestDispatcherTest.php
@@ -11,7 +11,8 @@ class AbstractHttpRequestDispatcherTest extends \PHPUnit_Framework_Testcase
 
     public function setUp()
     {
-        $httpClient = $this->getMock('Laminas\Http\Client');
+        $httpClient = $this->getMockBuilder('Laminas\Http\Client')
+            ->getMock();
         $this->dispatcher = $this->getMockBuilder('InoOicClient\Oic\AbstractHttpRequestDispatcher')
             ->setConstructorArgs(array(
             $httpClient
@@ -22,7 +23,8 @@ class AbstractHttpRequestDispatcherTest extends \PHPUnit_Framework_Testcase
 
     public function testConstructor()
     {
-        $httpClient = $this->getMock('Laminas\Http\Client');
+        $httpClient = $this->getMockBuilder('Laminas\Http\Client')
+            ->getMock();
         $options = array(
             'foo' => 'bar'
         );
@@ -53,8 +55,10 @@ class AbstractHttpRequestDispatcherTest extends \PHPUnit_Framework_Testcase
 
     public function testSetHttpClient()
     {
-        $httpClientOne = $this->getMock('Laminas\Http\Client');
-        $httpClientTwo = $this->getMock('Laminas\Http\Client');
+        $httpClientOne = $this->getMockBuilder('Laminas\Http\Client')
+            ->getMock();
+        $httpClientTwo = $this->getMockBuilder('Laminas\Http\Client')
+            ->getMock();
         
         $dispatcher = $this->getMockBuilder('InoOicClient\Oic\AbstractHttpRequestDispatcher')
             ->setConstructorArgs(array(
@@ -88,8 +92,10 @@ class AbstractHttpRequestDispatcherTest extends \PHPUnit_Framework_Testcase
     {
         $this->setExpectedException('InoOicClient\Oic\Exception\HttpClientException');
         
-        $httpRequest = $this->getMock('Laminas\Http\Request');
-        $httpClient = $this->getMock('Laminas\Http\Client');
+        $httpRequest = $this->getMockBuilder('Laminas\Http\Request')
+            ->getMock();
+        $httpClient = $this->getMockBuilder('Laminas\Http\Client')
+            ->getMock();
         $httpClient->expects($this->once())
             ->method('send')
             ->with($httpRequest)
@@ -104,9 +110,12 @@ class AbstractHttpRequestDispatcherTest extends \PHPUnit_Framework_Testcase
 
     public function testSendHttpRequest()
     {
-        $httpRequest = $this->getMock('Laminas\Http\Request');
-        $httpResponse = $this->getMock('Laminas\Http\Response');
-        $httpClient = $this->getMock('Laminas\Http\Client');
+        $httpRequest = $this->getMockBuilder('Laminas\Http\Request')
+            ->getMock();
+        $httpResponse = $this->getMockBuilder('Laminas\Http\Response')
+            ->getMock();
+        $httpClient = $this->getMockBuilder('Laminas\Http\Client')
+            ->getMock();
         $httpClient->expects($this->once())
             ->method('send')
             ->with($httpRequest)
@@ -123,14 +132,16 @@ class AbstractHttpRequestDispatcherTest extends \PHPUnit_Framework_Testcase
      */
     protected function createErrorFactoryMock()
     {
-        $factory = $this->getMock('InoOicClient\Oic\ErrorFactoryInterface');
+        $factory = $this->getMockBuilder('InoOicClient\Oic\ErrorFactoryInterface')
+            ->getMock();
         return $factory;
     }
 
 
     protected function createJsonCoderMock()
     {
-        $coder = $this->getMock('InoOicClient\Json\Coder');
+        $coder = $this->getMockBuilder('InoOicClient\Json\Coder')
+            ->getMock();
         return $coder;
     }
 }

--- a/tests/unit/InoOicClientTest/Oic/AbstractResponseHandlerTest.php
+++ b/tests/unit/InoOicClientTest/Oic/AbstractResponseHandlerTest.php
@@ -65,21 +65,24 @@ class AbstractResponseHandlerTest extends \PHPUnit_Framework_TestCase
      */
     protected function createErrorMock()
     {
-        $error = $this->getMock('InoOicClient\Oic\Error');
+        $error = $this->getMockBuilder('InoOicClient\Oic\Error')
+            ->getMock();
         return $error;
     }
 
 
     protected function createJsonCoderMock($input = null, $output = null, $throwsException = false)
     {
-        $coder = $this->getMock('InoOicClient\Json\Coder');
+        $coder = $this->getMockBuilder('InoOicClient\Json\Coder')
+            ->getMock();
         return $coder;
     }
 
 
     protected function createErrorFactoryMock()
     {
-        $factory = $this->getMock('InoOicClient\Oic\ErrorFactoryInterface');
+        $factory = $this->getMockBuilder('InoOicClient\Oic\ErrorFactoryInterface')
+            ->getMock();
         return $factory;
     }
 }

--- a/tests/unit/InoOicClientTest/Oic/Authorization/DispatcherTest.php
+++ b/tests/unit/InoOicClientTest/Oic/Authorization/DispatcherTest.php
@@ -235,7 +235,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
     protected function createUriGeneratorMock($request = null, $uri = null)
     {
-        $uriGenerator = $this->getMock('InoOicClient\Oic\Authorization\Uri\Generator');
+        $uriGenerator = $this->getMockBuilder('InoOicClient\Oic\Authorization\Uri\Generator')
+            ->getMock();
         if ($request && $uri) {
             $uriGenerator->expects(($this->once()))
                 ->method('createAuthorizationRequestUri')
@@ -248,7 +249,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
     protected function createStateManagerMock($validateHash = null, $throwException = false)
     {
-        $manager = $this->getMock('InoOicClient\Oic\Authorization\State\Manager');
+        $manager = $this->getMockBuilder('InoOicClient\Oic\Authorization\State\Manager')
+            ->getMock();
         if ($validateHash) {
             if ($throwException) {
                 $manager->expects($this->once())
@@ -286,7 +288,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
     protected function createResponseFactoryMock($code = null, $response = null, $state = null)
     {
-        $responseFactory = $this->getMock('InoOicClient\Oic\Authorization\ResponseFactoryInterface');
+        $responseFactory = $this->getMockBuilder('InoOicClient\Oic\Authorization\ResponseFactoryInterface')
+            ->getMock();
         if ($code && $response) {
             $responseFactory->expects($this->once())
                 ->method('createResponse')
@@ -299,7 +302,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
     protected function createHttpRequestMock($queryParams = array())
     {
-        $httpRequest = $this->getMock('Laminas\Http\Request');
+        $httpRequest = $this->getMockBuilder('Laminas\Http\Request')
+            ->getMock();
         $httpRequest->expects($this->once())
             ->method('getQuery')
             ->will($this->returnValue(new Parameters($queryParams)));
@@ -309,7 +313,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
     protected function createResponseMock()
     {
-        $response = $this->getMock('InoOicClient\Oic\Authorization\Response');
+        $response = $this->getMockBuilder('InoOicClient\Oic\Authorization\Response')
+            ->getMock();
         return $response;
     }
 }

--- a/tests/unit/InoOicClientTest/Oic/Authorization/State/ManagerTest.php
+++ b/tests/unit/InoOicClientTest/Oic/Authorization/State/ManagerTest.php
@@ -99,7 +99,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
     protected function createStorageMock($saveState = null, $loadState = null)
     {
-        $storage = $this->getMock('InoOicClient\Oic\Authorization\State\Storage\StorageInterface');
+        $storage = $this->getMockBuilder('InoOicClient\Oic\Authorization\State\Storage\StorageInterface')
+            ->getMock();
         if ($saveState) {
             $storage->expects($this->once())
                 ->method('saveState')
@@ -116,7 +117,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
     protected function createFactoryMock($state = null)
     {
-        $factory = $this->getMock('InoOicClient\Oic\Authorization\State\StateFactoryInterface');
+        $factory = $this->getMockBuilder('InoOicClient\Oic\Authorization\State\StateFactoryInterface')
+            ->getMock();
         if ($state) {
             $factory->expects($this->once())
                 ->method('createState')

--- a/tests/unit/InoOicClientTest/Oic/Token/DispatcherTest.php
+++ b/tests/unit/InoOicClientTest/Oic/Token/DispatcherTest.php
@@ -90,7 +90,8 @@ class DispatcherTest extends \PHPUnit_Framework_Testcase
         $httpRequest = $this->createHttpRequestMock();
         $httpResponse = $this->createHttpResponseMock();
         $builder = $this->createHttpRequestBuilderMock($request, $httpRequest);
-        $response = $this->getMock('InoOicClient\Oic\Token\Response');
+        $response = $this->getMockBuilder('InoOicClient\Oic\Token\Response')
+            ->getMock();
         
         $responseHandler = $this->createResponseHandlerMock($httpResponse, $response);
         
@@ -124,7 +125,8 @@ class DispatcherTest extends \PHPUnit_Framework_Testcase
 
     protected function createHttpRequestBuilderMock($tokenRequest = null, $httpRequest = null, $throwException = false)
     {
-        $builder = $this->getMock('InoOicClient\Oic\Token\HttpRequestBuilder');
+        $builder = $this->getMockBuilder('InoOicClient\Oic\Token\HttpRequestBuilder')
+            ->getMock();
         
         if ($throwException) {
             $builder->expects($this->once())
@@ -144,14 +146,16 @@ class DispatcherTest extends \PHPUnit_Framework_Testcase
 
     protected function createHttpRequestMock()
     {
-        $httpRequest = $this->getMock('Laminas\Http\Request');
+        $httpRequest = $this->getMockBuilder('Laminas\Http\Request')
+            ->getMock();
         return $httpRequest;
     }
 
 
     protected function createHttpResponseMock($content = null, $status = null, $error = false)
     {
-        $httpResponse = $this->getMock('Laminas\Http\Response');
+        $httpResponse = $this->getMockBuilder('Laminas\Http\Response')
+            ->getMock();
         
         if ($content) {
             $httpResponse->expects($this->once())
@@ -181,7 +185,8 @@ class DispatcherTest extends \PHPUnit_Framework_Testcase
 
     protected function createResponseMock()
     {
-        $response = $this->getMock('InoOicClient\Oic\Token\Response');
+        $response = $this->getMockBuilder('InoOicClient\Oic\Token\Response')
+            ->getMock();
         return $response;
     }
 
@@ -195,7 +200,8 @@ class DispatcherTest extends \PHPUnit_Framework_Testcase
 
     protected function createResponseHandlerMock($httpResponse = null, $response = null, $error = null)
     {
-        $handler = $this->getMock('InoOicClient\Oic\Token\ResponseHandler');
+        $handler = $this->getMockBuilder('InoOicClient\Oic\Token\ResponseHandler')
+            ->getMock();
         
         if ($httpResponse) {
             $handler->expects($this->once())
@@ -224,7 +230,8 @@ class DispatcherTest extends \PHPUnit_Framework_Testcase
 
     public function createErrorMock()
     {
-        $error = $this->getMock('InoOicClient\Oic\Error');
+        $error = $this->getMockBuilder('InoOicClient\Oic\Error')
+            ->getMock();
         return $error;
     }
 }

--- a/tests/unit/InoOicClientTest/Oic/Token/HttpRequestBuilderTest.php
+++ b/tests/unit/InoOicClientTest/Oic/Token/HttpRequestBuilderTest.php
@@ -87,14 +87,16 @@ class HttpRequestBuilderTest extends \PHPUnit_Framework_Testcase
      */
     protected function createAuthenticatorMock()
     {
-        $authenticator = $this->getMock('InoOicClient\Client\Authenticator\AuthenticatorInterface');
+        $authenticator = $this->getMockBuilder('InoOicClient\Client\Authenticator\AuthenticatorInterface')
+            ->getMock();
         return $authenticator;
     }
 
 
     protected function createClientAuthenticatorFactoryMock()
     {
-        $factory = $this->getMock('InoOicClient\Client\Authenticator\AuthenticatorFactoryInterface');
+        $factory = $this->getMockBuilder('InoOicClient\Client\Authenticator\AuthenticatorFactoryInterface')
+            ->getMock();
         return $factory;
     }
 
@@ -168,7 +170,8 @@ class HttpRequestBuilderTest extends \PHPUnit_Framework_Testcase
     protected function createHttpRequestMock($endpoint, $clientId, $redirectUri, $clientInfo, $code, $grantType, $method, 
         $headersList)
     {
-        $httpRequest = $this->getMock('Laminas\Http\Request');
+        $httpRequest = $this->getMockBuilder('Laminas\Http\Request')
+            ->getMock();
         $httpRequest->expects($this->once())
             ->method('setUri')
             ->with($endpoint);
@@ -183,7 +186,8 @@ class HttpRequestBuilderTest extends \PHPUnit_Framework_Testcase
             Param::CODE => $code
         );
         
-        $postVars = $this->getMock('Laminas\Stdlib\Parameters');
+        $postVars = $this->getMockBuilder('Laminas\Stdlib\Parameters')
+            ->getMock();
         $postVars->expects($this->once())
             ->method('fromArray')
             ->with($postData);
@@ -192,7 +196,8 @@ class HttpRequestBuilderTest extends \PHPUnit_Framework_Testcase
             ->method('getPost')
             ->will($this->returnValue($postVars));
         
-        $headers = $this->getMock('Laminas\Http\Headers');
+        $headers = $this->getMockBuilder('Laminas\Http\Headers')
+            ->getMock();
         $headers->expects($this->once())
             ->method('addHeaders')
             ->with($headersList);

--- a/tests/unit/InoOicClientTest/Oic/Token/RequestTest.php
+++ b/tests/unit/InoOicClientTest/Oic/Token/RequestTest.php
@@ -11,7 +11,8 @@ class RequestTest extends \PHPUnit_Framework_Testcase
 
     public function testSettersAndGetters()
     {
-        $clientInfo = $this->getMock('InoOicClient\Client\ClientInfo');
+        $clientInfo = $this->getMockBuilder('InoOicClient\Client\ClientInfo')
+            ->getMock();
         $grantType = 'authorization_code';
         $code = '1234';
         

--- a/tests/unit/InoOicClientTest/Oic/Token/ResponseFactoryTest.php
+++ b/tests/unit/InoOicClientTest/Oic/Token/ResponseFactoryTest.php
@@ -110,7 +110,8 @@ class ResponseFactoryTest extends \PHPUnit_Framework_Testcase
 
     protected function createHttpResponseMock($content = null)
     {
-        $httpResponse = $this->getMock('Laminas\Http\Response');
+        $httpResponse = $this->getMockBuilder('Laminas\Http\Response')
+            ->getMock();
         $httpResponse->expects($this->once())
             ->method('getContent')
             ->will($this->returnValue($content));
@@ -121,7 +122,8 @@ class ResponseFactoryTest extends \PHPUnit_Framework_Testcase
 
     protected function createResponseMock()
     {
-        $response = $this->getMock('InoOicClient\Oic\Token\Response');
+        $response = $this->getMockBuilder('InoOicClient\Oic\Token\Response')
+            ->getMock();
         return $response;
     }
 }

--- a/tests/unit/InoOicClientTest/Oic/Token/ResponseHandlerTest.php
+++ b/tests/unit/InoOicClientTest/Oic/Token/ResponseHandlerTest.php
@@ -110,7 +110,8 @@ class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
         $coder = $this->createJsonCoderMock($content, $data);
         $this->handler->setJsonCoder($coder);
         
-        $response = $this->getMock('InoOicClient\Oic\Token\Response');
+        $response = $this->getMockBuilder('InoOicClient\Oic\Token\Response')
+            ->getMock();
         $responseFactory = $this->createResponseFactoryMock($data, $response);
         $this->handler->setResponseFactory($responseFactory);
         
@@ -124,7 +125,8 @@ class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
      */
     protected function createHttpResponseMock($content, $isError = false)
     {
-        $httpResponse = $this->getMock('Laminas\Http\Response');
+        $httpResponse = $this->getMockBuilder('Laminas\Http\Response')
+            ->getMock();
         
         $httpResponse->expects($this->once())
             ->method('isSuccess')
@@ -142,7 +144,8 @@ class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
 
     protected function createJsonCoderMock($input = null, $output = null, $throwsException = false)
     {
-        $coder = $this->getMock('InoOicClient\Json\Coder');
+        $coder = $this->getMockBuilder('InoOicClient\Json\Coder')
+            ->getMock();
         
         if ($throwsException) {
             $coder->expects($this->once())
@@ -162,7 +165,8 @@ class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
 
     protected function createResponseFactoryMock($responseData = null, $response = null, $throwException = false)
     {
-        $factory = $this->getMock('InoOicClient\Oic\Token\ResponseFactoryInterface');
+        $factory = $this->getMockBuilder('InoOicClient\Oic\Token\ResponseFactoryInterface')
+            ->getMock();
         
         if ($throwException) {
             $factory->expects($this->once())

--- a/tests/unit/InoOicClientTest/Oic/UserInfo/DispatcherTest.php
+++ b/tests/unit/InoOicClientTest/Oic/UserInfo/DispatcherTest.php
@@ -83,7 +83,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
         $httpRequest = $this->createHttpRequestMock();
         $httpResponse = $this->createHttpResponseMock();
         $builder = $this->createHttpRequestBuilderMock($request, $httpRequest);
-        $response = $this->getMock('InoOicClient\Oic\UserInfo\Response');
+        $response = $this->getMockBuilder('InoOicClient\Oic\UserInfo\Response')
+            ->getMock();
         
         $responseHandler = $this->createResponseHandlerMock($httpResponse, $response);
         
@@ -117,7 +118,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
     protected function createResponseHandlerMock($httpResponse = null, $response = null, $error = null)
     {
-        $handler = $this->getMock('InoOicClient\Oic\UserInfo\ResponseHandler');
+        $handler = $this->getMockBuilder('InoOicClient\Oic\UserInfo\ResponseHandler')
+            ->getMock();
         
         if ($httpResponse) {
             $handler->expects($this->once())
@@ -146,7 +148,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
     protected function createHttpClientMock($httpRequest = null, $httpRespone = null, $throwException = false)
     {
-        $client = $this->getMock('Laminas\Http\Client');
+        $client = $this->getMockBuilder('Laminas\Http\Client')
+            ->getMock();
         
         return $client;
     }
@@ -154,28 +157,32 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
     protected function createHttpRequestMock()
     {
-        $httpRequest = $this->getMock('Laminas\Http\Request');
+        $httpRequest = $this->getMockBuilder('Laminas\Http\Request')
+            ->getMock();
         return $httpRequest;
     }
 
 
     protected function createHttpResponseMock()
     {
-        $httpResponse = $this->getMock('Laminas\Http\Response');
+        $httpResponse = $this->getMockBuilder('Laminas\Http\Response')
+            ->getMock();
         return $httpResponse;
     }
 
 
     protected function createUserInfoRequestMock()
     {
-        $request = $this->getMock('InoOicClient\Oic\UserInfo\Request');
+        $request = $this->getMockBuilder('InoOicClient\Oic\UserInfo\Request')
+            ->getMock();
         return $request;
     }
 
 
     protected function createHttpRequestBuilderMock($request = null, $httpRequest = null, $throwException = false)
     {
-        $builder = $this->getMock('InoOicClient\Oic\UserInfo\HttpRequestBuilder');
+        $builder = $this->getMockBuilder('InoOicClient\Oic\UserInfo\HttpRequestBuilder')
+            ->getMock();
         
         if ($throwException) {
             $builder->expects($this->once())
@@ -195,7 +202,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
     public function createErrorMock()
     {
-        $error = $this->getMock('InoOicClient\Oic\Error');
+        $error = $this->getMockBuilder('InoOicClient\Oic\Error')
+            ->getMock();
         return $error;
     }
 }

--- a/tests/unit/InoOicClientTest/Oic/UserInfo/HttpRequestBuilderTest.php
+++ b/tests/unit/InoOicClientTest/Oic/UserInfo/HttpRequestBuilderTest.php
@@ -38,7 +38,8 @@ class HttpRequestBuilderTest extends \PHPUnit_Framework_TestCase
             $headerName => $headerValue
         );
         
-        $headers = $this->getMock('Laminas\Http\Headers');
+        $headers = $this->getMockBuilder('Laminas\Http\Headers')
+            ->getMock();
         $headers->expects($this->once())
             ->method('addHeaders')
             ->with($headersList);
@@ -57,7 +58,8 @@ class HttpRequestBuilderTest extends \PHPUnit_Framework_TestCase
      */
     protected function createHttpRequest($method = null, $headers = null, $endpoint = null)
     {
-        $httpRequest = $this->getMock('Laminas\Http\Request');
+        $httpRequest = $this->getMockBuilder('Laminas\Http\Request')
+            ->getMock();
         
         if ($method) {
             $httpRequest->expects($this->once())

--- a/tests/unit/InoOicClientTest/Oic/UserInfo/RequestTest.php
+++ b/tests/unit/InoOicClientTest/Oic/UserInfo/RequestTest.php
@@ -12,7 +12,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testGettersAndSetters()
     {
         $token = 'abc';
-        $clientInfo = $this->getMock('InoOicClient\Client\ClientInfo');
+        $clientInfo = $this->getMockBuilder('InoOicClient\Client\ClientInfo')
+            ->getMock();
         
         $request = new Request();
         $request->setAccessToken($token);

--- a/tests/unit/InoOicClientTest/Oic/UserInfo/ResponseHandlerTest.php
+++ b/tests/unit/InoOicClientTest/Oic/UserInfo/ResponseHandlerTest.php
@@ -171,7 +171,7 @@ class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
         $values = array(
             'foo' => 'bar'
         );
-        $response = $this->getMock('InoOicClient\Oic\UserInfo\Response');
+        $response = $this->getMockBuilder('InoOicClient\Oic\UserInfo\Response')->getMock();
         
         $httpResponse = $this->createHttpResponseMock($content);
         $coder = $this->createJsonCoderMock($content, $values);
@@ -190,7 +190,8 @@ class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
      */
     protected function createHttpResponseMock($content)
     {
-        $httpResponse = $this->getMock('Laminas\Http\Response');
+        $httpResponse = $this->getMockBuilder('Laminas\Http\Response')
+            ->getMock();
         
         if ($content) {
             $httpResponse->expects($this->once())
@@ -207,7 +208,7 @@ class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
 
     protected function createResponseFactoryMock($responseData = null, $response = null, $throwException = false)
     {
-        $factory = $this->getMock('InoOicClient\Oic\UserInfo\ResponseFactoryInterface');
+        $factory = $this->getMockBuilder('InoOicClient\Oic\UserInfo\ResponseFactoryInterface')->getMock();
         
         if ($throwException) {
             $factory->expects($this->once())
@@ -227,7 +228,7 @@ class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
 
     protected function createJsonCoderMock($input = null, $output = null, $throwsException = false)
     {
-        $coder = $this->getMock('InoOicClient\Json\Coder');
+        $coder = $this->getMockBuilder('InoOicClient\Json\Coder')->getMock();
         
         if ($throwsException) {
             $coder->expects($this->once())
@@ -247,7 +248,7 @@ class ResponseHandlerTest extends \PHPUnit_Framework_TestCase
 
     protected function createErrorFactoryMock()
     {
-        $factory = $this->getMock('InoOicClient\Oic\ErrorFactoryInterface');
+        $factory = $this->getMockBuilder('InoOicClient\Oic\ErrorFactoryInterface')->getMock();
         return $factory;
     }
 }


### PR DESCRIPTION
With this PR I suggest using travis to run the tests on different php versions.

@bradjones1 The test `InoOicClientTest\Oic\Token\DispatcherTest::testGetHttpRequestBuilderWithImplicitValue` is currently failing. I'm not sure if the test is wrong or if something needs to be fixed in `InoOicClient\Oic\Token\Dispatcher::getHttpRequestBuilder()`. Can you help here?