### PR TITLE
ClientFactory - Allow merging of options with numeric keys

### DIFF
--- a/src/InoOicClient/Http/ClientFactory.php
+++ b/src/InoOicClient/Http/ClientFactory.php
@@ -60,7 +60,7 @@ class ClientFactory implements ClientFactoryInterface
      */
     public function mergeOptions($options)
     {
-        return ArrayUtils::merge($this->defaultOptions, ArrayUtils::iteratorToArray($options));
+        return ArrayUtils::merge($this->defaultOptions, ArrayUtils::iteratorToArray($options), true);
     }
 
 

--- a/tests/unit/InoOicClientTest/Http/ClientFactoryTest.php
+++ b/tests/unit/InoOicClientTest/Http/ClientFactoryTest.php
@@ -35,7 +35,8 @@ class ClientFactoryTest extends \PHPUnit_Framework_Testcase
             'sub' => array(
                 'subfoo' => 'subbar',
                 'subreplace' => 'subvalue'
-            )
+            ),
+            1 => false
         );
         
         $options = array(
@@ -44,7 +45,8 @@ class ClientFactoryTest extends \PHPUnit_Framework_Testcase
             'sub' => array(
                 'subnew' => 'suboption',
                 'subreplace' => 'subreplacedvalue'
-            )
+            ),
+            1 => true
         );
         
         $merged = array(
@@ -55,7 +57,8 @@ class ClientFactoryTest extends \PHPUnit_Framework_Testcase
                 'subfoo' => 'subbar',
                 'subreplace' => 'subreplacedvalue',
                 'subnew' => 'suboption'
-            )
+            ),
+            1 => true
         );
         
         $this->factory->setDefaultOptions($defaultOptions);


### PR DESCRIPTION
The method Laminas\Stdlib\ArrayUtils::merge takes a third argument
$preseveNumericKeys set to false by default. This method is used in
HttpFactory::mergeOptions to allow custom options to be passed to the
HTTP Client. Unfortunately, without setting $preserveNumericKeys at
true, numeric keys, like Curl options constants, are not merged, but
*added*.

This commit fixes this behaviour.